### PR TITLE
trying to keep Doxygen from running on the clang-format script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 before_install:
    - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
-   - curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/run-clang-format.py > run-clang-format.py
+   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/run-clang-format.py)
 
 
 install:


### PR DESCRIPTION
I added running clang-format to the `.travis.yml` and now it appears that Doxygen is complaining about the python file not being good C++