### PR TITLE
Fix #4 (try 2)

### DIFF
--- a/Adafruit_VCNL4040.h
+++ b/Adafruit_VCNL4040.h
@@ -114,10 +114,11 @@ typedef enum proximity_type {
  * Values to be matched against the byte returned from `getInterruptStatus`.
  */
 typedef enum interrupt_type {
-  VCNL4040_PROXIMITY_AWAY,
-  VCNL4040_PROXIMITY_CLOSE,
-  VCNL4040_AMBIENT_HIGH = 4,
-  VCNL4040_AMBIENT_LOW,
+  VCNL4040_PROXIMITY_AWAY = 1,
+  VCNL4040_PROXIMITY_CLOSE = 1 << 1,
+  VCNL4040_AMBIENT_HIGH = 1 << 4,
+  VCNL4040_AMBIENT_LOW = 1 << 5,
+  VCNL4040_PROXIMITY_PROTECT_MODE = 1 << 6
 } VCNL4040_InterruptType;
 
 /*!


### PR DESCRIPTION
This fixes some constants used for detecting changed interrupts. As mentioned in https://github.com/adafruit/Adafruit_VCNL4040/issues/4, they were previously described as integer values for and-ing, but were actually the bit offsets.

This replaces a previous PR where I made a boo-boo.